### PR TITLE
Add workaround for intermittent null in holder->message

### DIFF
--- a/src/SignalHandlerImpl.cc
+++ b/src/SignalHandlerImpl.cc
@@ -17,6 +17,10 @@ SignalHandlerImpl::~SignalHandlerImpl(){
 
 void SignalHandlerImpl::signal_callback(uv_async_t *handle, int status) {
     CallbackHolder* holder = (CallbackHolder*) handle->data;
+    /* Workaround intermittent null in holder->message */
+    if (holder->message == NULL) {
+      return;
+    }
 
     v8::Local<v8::Object> msg = v8::Object::New();
     size_t msgIndex = 0;


### PR DESCRIPTION
I am not sure just skipping handling a signal when holder->message is null is correct way to work around this issue. However, with this workaround, it is able to handle following signals. This issue happens about 1 out of 10 signals. 